### PR TITLE
Add support for end-of-options flag (--)

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,6 +21,10 @@ do
                 kubeval_options+=("$2")
                 shift 2
                 ;;
+            --)
+                eoo=1
+                shift
+                ;;
             *)
                 helm_options+=("$1")
                 shift


### PR DESCRIPTION
All parameters after the `--` flag will be passed directly to helm.

Example usage looks like

    helm kubeval myChart -- --version 1.0

This is useful for the reasons described in #5; specifically, `helm template` supports a `--version` flag that is currently intercepted by helm-kubeval, with no way to pass it through.

Based on the implementation of `run.sh` it looks like this feature was intended to be supported, because there's an `eoo` (end-of-options) variable that is checked but never set. If `eoo` is ever nonzero (which it cannot be in its current state), then all options go straight to `helm` without be intercepted.